### PR TITLE
Fix importing "Pattern" class 

### DIFF
--- a/mailparser_reply/parser.py
+++ b/mailparser_reply/parser.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from itertools import chain
 from typing import Union, List, Optional, Tuple
 
-from typing.re import Pattern
+from typing import Pattern
 
 from .constants import MAIL_LANGUAGES, MAIL_LANGUAGE_DEFAULT, OUTLOOK_MAIL_SEPARATOR, QUOTED_REMOVAL_REGEX, \
     SINGLE_SPACE_VARIATIONS, SENTENCE_START, OPTIONAL_LINEBREAK, DEFAULT_SIGNATURE_REGEX, QUOTED_MATCH_INCLUDE, \


### PR DESCRIPTION
I got a deprecation warning at mailparser_reply.

This simple PR is to fix the warning.

```
..... /.venv/lib/python3.11/site-packages/mailparser_reply/parser.py:9: 
DeprecationWarning: typing.re is deprecated, import directly from typing instead. 
typing.re will be removed in Python 3.12.


    from typing.re import Pattern
```