### PR TITLE
Fixing failed tests for Polish.

### DIFF
--- a/mailparser_reply/constants.py
+++ b/mailparser_reply/constants.py
@@ -146,12 +146,12 @@ MAIL_LANGUAGES: Dict[str, Dict[str, str]] = {
         'sent_from': 'Verzonden vanaf mijn',
     },
     'pl': {
-        'wrote_header': r'^(?!Dnia[.\s]*Dnia\s(.+?\s?.+?)\snadesłał:)('
+        'wrote_header': r'^(?!Dnia[.\s]*Dnia\s(.+?\s?.+?)\s(?:nadesłał|napisał\(a\)):)('
                         + QUOTED_MATCH_INCLUDE
-                        + r'Dnia\s(?:.+?\s?.+?)\s?nadesłał:)$',
+                        + r'Dnia\s(?:.+?\s?.+?)\s?(?:nadesłał|napisał\(a\)):)$',
         'from_header': r'((?:(?:^|\n|\n'
                        + QUOTED_MATCH_INCLUDE
-                       + r')[* ]*(?:Od|Wysłano|Do|Temat|Data|DW):[ *]*(?:\s{,2}).*){2,}(?:\n.*){,1})',
+                       + r')[* ]*(?:Od|Wysłano|Do|Temat|Data|DW):[ *]*(?:\s{,2}).*){1,}(?:\n.*){,1})',
         'disclaimers': [
             'Uwaga:'
         ],


### PR DESCRIPTION
While checking https://github.com/alfonsrv/mail-parser-reply/pull/12 is fixed, I realized a test for pl fails since some commits.

Although I do not know Polish, I confirmed that the test case works by modifying the constraints.py to show the cause of the parsing failure.