### PR TITLE
Optimise emails

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+    "python.testing.unittestArgs": [
+        "-v",
+        "-s",
+        "./mailparser_reply",
+        "-p",
+        "test*.py"
+    ],
+    "python.testing.pytestEnabled": false,
+    "python.testing.unittestEnabled": true
+}

--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ Currently supported languages are:
 * German (`de`) 🇩🇪
 * Italian (`it`) 🇮🇹
 * Japanese (`ja`) 🇯🇵
-* Polish (`pl`) 🇵🇱 
+* Polish (`pl`) 🇵🇱
+* Korean (`ko`) 🇰🇷
+* Chinese (`zh`) 🇨🇳
+* Spanish (`es`) 🇪🇸
+* Czech (`cs`) 🇨🇿
 
 
 🏳️‍🌈 **Adding more languages is quite easy!**

--- a/mailparser_reply/constants.py
+++ b/mailparser_reply/constants.py
@@ -163,11 +163,69 @@ MAIL_LANGUAGES: Dict[str, Dict[str, str]] = {
         ],
         'sent_from': 'Wysłano z'
     },
-    'david': {
-        # Custom Software Headers – also kind of like a language, right?
-        'from_header': r'((?:^ *' + QUOTED_MATCH_INCLUDE + r'\[?Original Message processed by david.+?$\n{,4})'
-                       + r'(?:.*\n?){,2}'  # david's non-subject line + date wildcard identification
-                       + r'(?:(?:^|\n|\n'
-                       + QUOTED_MATCH_INCLUDE + r')[* ]*(?:Von|An|Cc)(?:\s{,2}).*){2,})'
+    'zh': {
+        'wrote_header': r'^(?!.*\d{4}年\d{1,2}月\d{1,2}日.*?写道：)('
+                        + QUOTED_MATCH_INCLUDE
+                        + r'\d{4}年\d{1,2}月\d{1,2}日.*?写道：)$',
+        'from_header': r'((?:(?:^|\n|\n'
+                       + QUOTED_MATCH_INCLUDE
+                       + r')[* ]*(?:发件人|发送时间|收件人|主题|抄送|组织):[ *]*(?:\s{,2}).*){2,}(?:\n.*){,1})',
+        'disclaimers': [
+            '免责声明：',
+            '注意：',
+            '重要信息：',
+        ],
+        'signatures': [
+            '此致，',
+            '敬礼，',
+            '谢谢，',
+            '谢谢您的关注，',
+            '祝好，',
+        ],
+        'sent_from': r'从我的.*发送',
+    },
+    'ko': {
+        'wrote_header': r'^(?!.*\d{4}년 \d{1,2}월 \d{1,2}일.*?님이 작성하였습니다:)('
+                        + QUOTED_MATCH_INCLUDE
+                        + r'\d{4}년 \d{1,2}월 \d{1,2}일 .*님이 작성하였습니다:)$',
+        'from_header': r'((?:(?:^|\n|\n'
+                       + QUOTED_MATCH_INCLUDE
+                       + r')[* ]*(?:보낸\s?사람|보낸\s?날짜|받는\s?사람|제목|참조):[ *]*(?:\s{,2}).*){2,}(?:\n.*){,1})',
+        'disclaimers': [
+            '주의:',
+            '면책 조항:',
+            '비밀정보:',
+        ],
+        'signatures': [
+            '감사합니다,',
+            '안부 전합니다,',
+            '좋은 하루 되세요,',
+            '고맙습니다,',
+            '감사합니다.',
+        ],
+        'sent_from': r'내 .*에서 보냄',
+    },
+    'es': {
+        'wrote_header': r'^(?!El\s.+\s escribió:)('
+                        + QUOTED_MATCH_INCLUDE
+                        + r'El\s.+\s escribió:)$',
+        'from_header': r'((?:(?:^|\n|\n'
+                       + QUOTED_MATCH_INCLUDE
+                       + r')[* ]*(?:De|Enviado|Para|Asunto|Fecha|CC|Organización):[ *]*(?:\s{,2}).*){2,}(?:\n.*){,1})',
+        'disclaimers': [
+            'Aviso:',
+            'Confidencialidad:',
+            'Advertencia:',
+            'Descargo de responsabilidad:',
+        ],
+        'signatures': [
+            'Saludos,',
+            'Atentamente,',
+            'Gracias,',
+            'Un saludo,',
+            'Cordialmente,',
+            'Muchas gracias,',
+        ],
+        'sent_from': r'Enviado desde mi.*',
     },
 }

--- a/mailparser_reply/constants.py
+++ b/mailparser_reply/constants.py
@@ -228,4 +228,25 @@ MAIL_LANGUAGES: Dict[str, Dict[str, str]] = {
         ],
         'sent_from': r'Enviado desde mi.*',
     },
+    'cs': {
+        'wrote_header': r'^(?!Dne[.\s]*Dne\s(.+?\s?.+?)\snapsal\(a\):)('
+                        + QUOTED_MATCH_INCLUDE
+                        + r'Dne\s(?:.+?\s?.+?)\s?napsal\(a\):)$',
+        'from_header': r'((?:(?:^|\n|\n'
+                       + QUOTED_MATCH_INCLUDE
+                       + r')[* ]*(?:Od|Odesláno|Komu|Předmět|Datum|Kopie):[ *]*(?:\s{,2}).*){2,}(?:\n.*){,1})',
+        'disclaimers': [
+            'Upozornění:',
+            'Důvěrné:',
+            'Varování:',
+        ],
+        'signatures': [
+            'S pozdravem,',
+            'S úctou,',
+            'Děkuji,',
+            'Děkujeme,',
+            'S přáním hezkého dne,',
+        ],
+        'sent_from': r'Odesláno z mého.*',
+    },
 }

--- a/test/test_email_reply_parser.py
+++ b/test/test_email_reply_parser.py
@@ -65,7 +65,6 @@ class EmailMessageTest(unittest.TestCase):
     def test_gmail_header(self):
         mail = self.get_email('email_2_1', parse=True, languages=['en'])
         self.assertEqual(2, len(mail.replies))
-        print('ok')
         print(mail.replies[0].body)
         self.assertTrue("Outlook with a reply" == mail.replies[0].body)
         self.assertTrue("Google Apps Sync Team [mailto:mail-noreply@google.com]" in mail.replies[1].headers)
@@ -181,7 +180,6 @@ class EmailMessageTest(unittest.TestCase):
             languages=languages or [MAIL_LANGUAGE_DEFAULT]
         ).read(text) if parse else text
 
-
 class PerformanceTest(unittest.TestCase):
     def test_performance_complex_email(self):
         start = time.time()
@@ -210,6 +208,7 @@ class PerformanceTest(unittest.TestCase):
         elapsed = time.time() - start
         print(f"Performance test: Parsing 'multi_header.txt' took {elapsed:.4f} seconds and found {len(mail.replies)} replies.")
         self.assertLess(elapsed, 2.0, f"Parsing took too long: {elapsed:.4f} seconds")
+
 
 
 if __name__ == '__main__':

--- a/test/test_email_reply_parser.py
+++ b/test/test_email_reply_parser.py
@@ -2,6 +2,7 @@ import os
 import sys
 import unittest
 import logging
+import time
 
 base_path = os.path.realpath(os.path.dirname(__file__))
 root = os.path.join(base_path, '..')
@@ -64,7 +65,9 @@ class EmailMessageTest(unittest.TestCase):
     def test_gmail_header(self):
         mail = self.get_email('email_2_1', parse=True, languages=['en'])
         self.assertEqual(2, len(mail.replies))
-        self.assertTrue("Outlook with a reply\n\n\n------------------------------" == mail.replies[0].body)
+        print('ok')
+        print(mail.replies[0].body)
+        self.assertTrue("Outlook with a reply" == mail.replies[0].body)
         self.assertTrue("Google Apps Sync Team [mailto:mail-noreply@google.com]" in mail.replies[1].headers)
         self.assertTrue("Google Apps Sync Team [mailto:mail-noreply@google.com]" not in mail.replies[1].body)
 
@@ -140,7 +143,7 @@ class EmailMessageTest(unittest.TestCase):
     def test_dutch_gmail_header(self):
         mail = self.get_email('email_nl_1_2', parse=True, languages=['nl'])
         self.assertEqual(2, len(mail.replies))
-        self.assertTrue("Outlook met een antwoord\n\n\n------------------------------" == mail.replies[0].body)
+        self.assertTrue("Outlook met een antwoord" == mail.replies[0].body)
         self.assertTrue("Google Apps Sync Team [mailto:mail-noreply@google.com]" in mail.replies[1].headers)
         self.assertTrue("Google Apps Sync Team [mailto:mail-noreply@google.com]" not in mail.replies[1].body)
 
@@ -177,6 +180,36 @@ class EmailMessageTest(unittest.TestCase):
         return EmailReplyParser(
             languages=languages or [MAIL_LANGUAGE_DEFAULT]
         ).read(text) if parse else text
+
+
+class PerformanceTest(unittest.TestCase):
+    def test_performance_complex_email(self):
+        start = time.time()
+        # Use correct relative path from the test directory
+        with open('emails/email_3_1.txt') as f:
+            text = f.read()
+        mail = EmailReplyParser(languages=['en', 'de', 'david']).read(text)
+        elapsed = time.time() - start
+        print(f"Performance test: Parsing 'email_3_1.txt' took {elapsed:.4f} seconds and found {len(mail.replies)} replies.")
+        self.assertLess(elapsed, 2.0, f"Parsing took too long: {elapsed:.4f} seconds")
+
+    def test_performance_pathological(self):
+        start = time.time()
+        with open('emails/pathological.txt') as f:
+            text = f.read()
+        mail = EmailReplyParser(languages=['en', 'de', 'david']).read(text)
+        elapsed = time.time() - start
+        print(f"Performance test: Parsing 'pathological.txt' took {elapsed:.4f} seconds and found {len(mail.replies)} replies.")
+        self.assertLess(elapsed, 2.0, f"Parsing took too long: {elapsed:.4f} seconds")
+
+    def test_performance_multi_header(self):
+        start = time.time()
+        with open('emails/multi_header.txt') as f:
+            text = f.read()
+        mail = EmailReplyParser(languages=['en', 'de', 'david']).read(text)
+        elapsed = time.time() - start
+        print(f"Performance test: Parsing 'multi_header.txt' took {elapsed:.4f} seconds and found {len(mail.replies)} replies.")
+        self.assertLess(elapsed, 2.0, f"Parsing took too long: {elapsed:.4f} seconds")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- The EmailReply.body property uses multiple `.replace()` calls in a loop to remove disclaimers and signatures. This creates many intermediate strings and is less efficient than a single re.sub() call.

- `text.find()` inefficient,  A single call to re.split() is much faster as it performs the entire operation in its highly optimized C implementation.

- ` @functools.lru_cache`, the regex for a given set of languages will be compiled only once and then reused from a cache.