### PR TITLE
Add line anchoring to fr wrote_header

### DIFF
--- a/mailparser_reply/constants.py
+++ b/mailparser_reply/constants.py
@@ -138,9 +138,9 @@ MAIL_LANGUAGES: Dict[str, Dict[str, str]] = {
         'sent_from': r'Enviado desde mi.*',
     },
     'fr': {
-        'wrote_header': r'(?!Le.*Le\s.+?a \u00e9crit[a-zA-Z0-9.:;<>()&@ -]*:)('
+        'wrote_header': r'^(?!Le.*Le\s.+?a \u00e9crit[a-zA-Z0-9.:;<>()&@ -]*:)('
                         + QUOTED_MATCH_INCLUDE
-                        + r'Le\s(.+?)a \u00e9crit[a-zA-Z0-9.:;<>()&@ -]*:)',
+                        + r'Le\s(.+?)a \u00e9crit[a-zA-Z0-9.:;<>()&@ -]*:)$',
         'from_header': r'((?:(?:^|\n|\n'
                        + QUOTED_MATCH_INCLUDE
                        + r')[* ]*(?:De |Envoy\u00e9 |\u00C0 |Objet |  |Cc ):[ *]*(?:\s{,2}).*){2,}(?:\n.*){,1})',


### PR DESCRIPTION
I have noticed that the fr wrote_header regex does not have ^ and $ characters at the beginning and end of the string, respectively. As a result of this, I have noticed that attempting to parse certain extremely long strings takes several minutes, or even longer. As far as I can tell, fr is the only language that does not have these line anchors for the wrote_header, so I am assuming this was just an oversight and they can be safely added? Admittedly, I am largely unfamiliar with both the French language and regex's, so please let me know if there is a reason for this.