### PR TITLE
Fix Pattern import for Python 3.12+ (prereq)

### DIFF
--- a/mailparser_reply/parser.py
+++ b/mailparser_reply/parser.py
@@ -4,9 +4,8 @@ import logging
 import re
 from dataclasses import dataclass, field
 from itertools import chain
+from re import Pattern
 from typing import Union, List, Optional, Tuple
-
-from typing.re import Pattern
 
 from .constants import MAIL_LANGUAGES, MAIL_LANGUAGE_DEFAULT, OUTLOOK_MAIL_SEPARATOR, QUOTED_REMOVAL_REGEX, \
     SINGLE_SPACE_VARIATIONS, SENTENCE_START, OPTIONAL_LINEBREAK, DEFAULT_SIGNATURE_REGEX, QUOTED_MATCH_INCLUDE, \


### PR DESCRIPTION
`typing.re` was removed in Python 3.12; the import raises ModuleNotFoundError on modern interpreters and blocks the entire test suite from collecting. `re.Pattern` has been the canonical location since Python 3.8.

