### PR TITLE
fix: update regex flags for multiline processing in EmailMessage class

### DIFF
--- a/mailparser_reply/parser.py
+++ b/mailparser_reply/parser.py
@@ -166,7 +166,7 @@ class EmailMessage:
         # In order to ensure that these fragments are split correctly, make sure that all lines
         # of underscores are preceded by at least two newline characters.
         #   See email_2_2.txt for an example
-        self.text = re.sub(f'([^\n]){OUTLOOK_MAIL_SEPARATOR}', '\\1\n', self.text, flags=re.MULTILINE)
+        self.text = re.sub(r"(\n ?[_-]{32,})", "\n\\1", self.text)
 
     def _process_signatures_disclaimers(self, text: str) -> Tuple[List[str], str]:
         """ Identifies Signature Elements and Disclaimers """

--- a/mailparser_reply/parser.py
+++ b/mailparser_reply/parser.py
@@ -166,7 +166,7 @@ class EmailMessage:
         # In order to ensure that these fragments are split correctly, make sure that all lines
         # of underscores are preceded by at least two newline characters.
         #   See email_2_2.txt for an example
-        self.text = re.sub(f'([^\n]){OUTLOOK_MAIL_SEPARATOR}', '\\1\n', self.text, re.MULTILINE)
+        self.text = re.sub(f'([^\n]){OUTLOOK_MAIL_SEPARATOR}', '\\1\n', self.text, flags=re.MULTILINE)
 
     def _process_signatures_disclaimers(self, text: str) -> Tuple[List[str], str]:
         """ Identifies Signature Elements and Disclaimers """

--- a/test/test_email_reply_parser.py
+++ b/test/test_email_reply_parser.py
@@ -88,6 +88,11 @@ class EmailMessageTest(unittest.TestCase):
         self.assertTrue("Google Apps Sync Team [mailto:mail-noreply@google.com]" in mail.replies[1].headers)
         self.assertTrue("Google Apps Sync Team [mailto:mail-noreply@google.com]" not in mail.replies[1].body)
 
+    def test_outlook_reply_directly_above_line(self):
+        mail = self.get_email('email_2_2', parse=True, languages=['en'])
+        self.assertEqual(2, len(mail.replies))
+        self.assertEqual("Outlook with a reply directly above line", mail.replies[0].body)
+
     def test_gmail_indented(self):
         mail = self.get_email('email_2_3', parse=True, languages=['en'])
         self.assertEqual(2, len(mail.replies))


### PR DESCRIPTION
Fixing warning (and actually maybe bug?) with python 3.14.

I’ll try to see if I can add a test to prove that we actually had a bug.

Fix: #29 