### PR TITLE
fix: handle wrapped Gmail quote headers across all languages

### DIFF
--- a/mailparser_reply/constants.py
+++ b/mailparser_reply/constants.py
@@ -73,6 +73,8 @@ MAIL_LANGUAGES: Dict[str, Dict[str, str]] = {
             'All the best',
             'regards,',
         ],
+        'gmail_wrap_start': r'On',
+        'gmail_wrap_keyword': r'wrote',
         'sent_from': 'Sent from my|Get Outlook for',
     },
     'de': {
@@ -91,6 +93,8 @@ MAIL_LANGUAGES: Dict[str, Dict[str, str]] = {
             r'Mit freundlichen Gr\u00fc\u00DFen / (?:Best|Kind) regards,',
             r'(?:(?:Beste(?:n)?|Liebe|Viele) )?(?:Gr(?:\u00fc|ue)(?:\u00DF|ss)(?:e)?|Gru\u00DF|Gruss)',
         ],
+        'gmail_wrap_start': r'Am',
+        'gmail_wrap_keyword': r'schrieb',
         'sent_from': 'Gesendet von',
     },
     'cs': {
@@ -112,6 +116,8 @@ MAIL_LANGUAGES: Dict[str, Dict[str, str]] = {
             'Děkujeme,',
             'S přáním hezkého dne,',
         ],
+        'gmail_wrap_start': r'Dne',
+        'gmail_wrap_keyword': r'napsal\(a\)',
         'sent_from': r'Odesláno z mého.*',
     },
     'da': {
@@ -141,6 +147,8 @@ MAIL_LANGUAGES: Dict[str, Dict[str, str]] = {
             'Tak',
             'På forhånd tak',
         ],
+        'gmail_wrap_start': r'Den',
+        'gmail_wrap_keyword': r'skrev',
         'sent_from': 'Sendt fra min|Sendt fra|Hent Outlook til|Sendt fra Outlook',
     },
     'es': {
@@ -164,6 +172,8 @@ MAIL_LANGUAGES: Dict[str, Dict[str, str]] = {
             'Cordialmente,',
             'Muchas gracias,',
         ],
+        'gmail_wrap_start': r'El',
+        'gmail_wrap_keyword': r'escribi[oó]',
         'sent_from': r'Enviado desde mi.*',
     },
     'fr': {
@@ -179,6 +189,8 @@ MAIL_LANGUAGES: Dict[str, Dict[str, str]] = {
             r'bonne r[\u00e9e]ception',
             r'bonne journ[\u00e9e]e',
         ],
+        'gmail_wrap_start': r'Le',
+        'gmail_wrap_keyword': r'a [eé]crit',
         'sent_from': r'Envoy\u00e9 depuis',
     },
     'it': {
@@ -191,6 +203,8 @@ MAIL_LANGUAGES: Dict[str, Dict[str, str]] = {
         'signatures': [
             'Cordiali saluti',
         ],
+        'gmail_wrap_start': r'Il',
+        'gmail_wrap_keyword': r'ha scritto',
         'sent_from': 'Inviato da',
     },
     'ja': {
@@ -242,6 +256,8 @@ MAIL_LANGUAGES: Dict[str, Dict[str, str]] = {
             'Bedankt,',
             'Dank u,',
         ],
+        'gmail_wrap_start': r'Op',
+        'gmail_wrap_keyword': r'schreef',
         'sent_from': 'Verzonden vanaf mijn',
     },
     'pl': {
@@ -263,9 +279,15 @@ MAIL_LANGUAGES: Dict[str, Dict[str, str]] = {
         'sent_from': 'Wysłano z'
     },
     'sv': {
+        # Matches both the single-line "Den ... skrev <sender>:" form and the
+        # wrapped Gmail form where the header runs onto a second line ending
+        # in just "skrev:" (no sender on the same line). The wrap is allowed
+        # via "(?:\n[ \t]*)?" and the sender between "skrev" and ":" is
+        # optional so a bare "skrev:" on its own line also matches.
         'wrote_header': r"^(?!Den[.\s]*Den\s(.+?\s?.+?)\skrev:)("
                         + QUOTED_MATCH_INCLUDE
-                        + r"(?:Den|[Mm]ån|[Tt]is|[Oo]ns|[Tt]or|[Ff]re|[Ll]ör|[Ss]ön|(?:[0-9]+\s+(?:jan|feb|mar|apr|maj|jun|jul|aug|sep|okt|nov|dec)))[^\n]*skrev\s(?:.+?\s?.+?):)$",
+                        + r"(?:Den|[Mm]ån|[Tt]is|[Oo]ns|[Tt]or|[Ff]re|[Ll]ör|[Ss]ön|(?:[0-9]+\s+(?:jan|feb|mar|apr|maj|jun|jul|aug|sep|okt|nov|dec)))"
+                        + r"[^\n]*?(?:\n[ \t]*)?skrev[ \t]*(?:[^\n:]*?)?:)$",
         'disclaimers': [
             'Varning:',
             'Observera:',
@@ -278,6 +300,8 @@ MAIL_LANGUAGES: Dict[str, Dict[str, str]] = {
             'Mvh',
             r'/\w+',  # To match /John, /Anna, etc.
         ],
+        'gmail_wrap_start': r'Den',
+        'gmail_wrap_keyword': r'skrev',
         'sent_from': 'Skickat från min',
         'from_header': r'((?:(?:^|\n|\n'
                        + QUOTED_MATCH_INCLUDE

--- a/mailparser_reply/parser.py
+++ b/mailparser_reply/parser.py
@@ -123,13 +123,17 @@ class EmailMessage:
         regex_headers = [self._get_language_regex(language=language, regex_key='wrote_header') for language in self.languages]
         regex_headers += [self._get_language_regex(language=language, regex_key='from_header') for language in self.languages]
         regex_headers.append(f'({GENERIC_MAIL_SEPARATOR})')
-        # Gmail wraps long quote headers onto two lines, leaving the
-        # wrote-keyword alone ("<start> ... <email>\\n<keyword>:"). Per-language
-        # `wrote_header` patterns are line-anchored and miss this layout — assemble
-        # a cross-language wrap matcher from the `gmail_wrap_start` /
-        # `gmail_wrap_keyword` tokens of each configured language. Languages that
-        # don't set the tokens (e.g. ja, whose Gmail format differs) simply don't
-        # contribute, preserving the per-language opt-in.
+        # Gmail wraps long quote headers onto two lines at ~76 chars. Two shapes
+        # show up depending on where the recipient lands relative to the wrote-
+        # keyword; both are language-agnostic and built from each configured
+        # language's `gmail_wrap_start` / `gmail_wrap_keyword` tokens (languages
+        # that don't set them — e.g. ja — simply don't contribute).
+        # Per-language `wrote_header` patterns are line-anchored and miss these.
+        #   1) Wrap BEFORE keyword (en/nl/it/es/cs/da style — verb at end):
+        #        "<start> ... <recipient> <email>\\n<keyword>:"
+        #   2) Wrap INSIDE recipient (sv/da/de style — verb in middle, ":" at
+        #      end of line; wrap falls inside the recipient's "<...>" bracket):
+        #        "<start> ... <keyword> <name> <\\nemail>:"
         starts = [self._get_language_regex(language=l, regex_key='gmail_wrap_start') for l in self.languages]
         keywords = [self._get_language_regex(language=l, regex_key='gmail_wrap_keyword') for l in self.languages]
         starts = '|'.join([s for s in starts if s])
@@ -138,6 +142,10 @@ class EmailMessage:
             regex_headers.append(
                 f'(^{QUOTED_MATCH_INCLUDE}(?:{starts})\\s[^\\n]+\\n[ \\t]*'
                 f'(?:{keywords})[ \\t]*(?:[^\\n:]*?)?:$)'
+            )
+            regex_headers.append(
+                f'(^{QUOTED_MATCH_INCLUDE}(?:{starts})\\s[^\\n]*?'
+                f'(?:{keywords})[ \\t]+[^\\n:]*\\n[ \\t]*[^\\n:]*?:$)'
             )
         regex_headers = '|'.join([header for header in regex_headers if header])
         self._header_regex = re.compile(regex_headers, flags=re.MULTILINE | re.IGNORECASE)

--- a/mailparser_reply/parser.py
+++ b/mailparser_reply/parser.py
@@ -123,6 +123,22 @@ class EmailMessage:
         regex_headers = [self._get_language_regex(language=language, regex_key='wrote_header') for language in self.languages]
         regex_headers += [self._get_language_regex(language=language, regex_key='from_header') for language in self.languages]
         regex_headers.append(f'({GENERIC_MAIL_SEPARATOR})')
+        # Gmail wraps long quote headers onto two lines, leaving the
+        # wrote-keyword alone ("<start> ... <email>\\n<keyword>:"). Per-language
+        # `wrote_header` patterns are line-anchored and miss this layout — assemble
+        # a cross-language wrap matcher from the `gmail_wrap_start` /
+        # `gmail_wrap_keyword` tokens of each configured language. Languages that
+        # don't set the tokens (e.g. ja, whose Gmail format differs) simply don't
+        # contribute, preserving the per-language opt-in.
+        starts = [self._get_language_regex(language=l, regex_key='gmail_wrap_start') for l in self.languages]
+        keywords = [self._get_language_regex(language=l, regex_key='gmail_wrap_keyword') for l in self.languages]
+        starts = '|'.join([s for s in starts if s])
+        keywords = '|'.join([k for k in keywords if k])
+        if starts and keywords:
+            regex_headers.append(
+                f'(^{QUOTED_MATCH_INCLUDE}(?:{starts})\\s[^\\n]+\\n[ \\t]*'
+                f'(?:{keywords})[ \\t]*(?:[^\\n:]*?)?:$)'
+            )
         regex_headers = '|'.join([header for header in regex_headers if header])
         self._header_regex = re.compile(regex_headers, flags=re.MULTILINE | re.IGNORECASE)
         logger.debug(f'Mail Header RegEx: "{self._header_regex.pattern!r}"')

--- a/test/emails/email_cs_wrap.txt
+++ b/test/emails/email_cs_wrap.txt
@@ -1,0 +1,12 @@
+Ahoj Anno,
+
+děkuji za zprávu. Podmínky mi vyhovují, ozvu se ti zítra dopoledne.
+
+S pozdravem,
+B
+
+
+Dne po 15. led. 2025 17:03 Anna Anderssonová <anna.anderssonova@example.com>
+napsal(a):
+
+> Ahoj B, pozice je opět otevřená. Jsi příští měsíc volný?

--- a/test/emails/email_da_wrap.txt
+++ b/test/emails/email_da_wrap.txt
@@ -1,0 +1,13 @@
+Hej Anna,
+
+vilkårene lyder fornuftige, og jeg er ledig fra næste måned. Lad os tales
+ved i morgen formiddag.
+
+Hilsen
+B
+
+
+Den man 15 jan 2025 17:03 Anna Andersson <anna.andersson@example.com>
+skrev:
+
+> Hej B, stillingen er åben igen. Er du ledig næste måned?

--- a/test/emails/email_de_wrap.txt
+++ b/test/emails/email_de_wrap.txt
@@ -1,0 +1,13 @@
+Hallo Anna,
+
+danke für die Nachricht. Die Konditionen klingen passend, lass uns morgen
+kurz telefonieren.
+
+Viele Grüße
+B
+
+
+Am Mo., 15. Jan. 2025, 17:03 Anna Andersson <anna.andersson@example.com>
+schrieb:
+
+> Hallo B, die Stelle ist wieder offen. Bist du im nächsten Monat verfügbar?

--- a/test/emails/email_de_wrap_inside.txt
+++ b/test/emails/email_de_wrap_inside.txt
@@ -1,0 +1,13 @@
+Hallo Anna,
+
+danke für die Nachricht. Die Konditionen klingen passend, lass uns morgen
+kurz telefonieren.
+
+Viele Grüße
+B
+
+
+Am Mo., 15. Jan. 2025, 17:03 schrieb Anna Andersson <
+anna.andersson@example.com>:
+
+> Hallo B, die Stelle ist wieder offen. Bist du im nächsten Monat verfügbar?

--- a/test/emails/email_en_wrap.txt
+++ b/test/emails/email_en_wrap.txt
@@ -1,0 +1,13 @@
+Hi Anna,
+
+Thanks for the offer — the timing could work. Could you share the rate and
+the start date?
+
+/B
+
+
+On Mon, Jan 15, 2025, 5:03 PM Anna Andersson <anna.andersson@example.com>
+wrote:
+
+> Hi B, hope you're well. The role I mentioned is open again. Are you
+> available next month?

--- a/test/emails/email_es_wrap.txt
+++ b/test/emails/email_es_wrap.txt
@@ -1,0 +1,13 @@
+Hola Anna,
+
+Gracias por escribirme. Las condiciones me parecen razonables, puedo hablar
+mañana por la mañana.
+
+Saludos
+B
+
+
+El lun, 15 ene 2025 a las 17:03, Anna Andersson <anna.andersson@example.com>
+escribió:
+
+> Hola B, el puesto vuelve a estar abierto. ¿Estás disponible el próximo mes?

--- a/test/emails/email_fr_wrap.txt
+++ b/test/emails/email_fr_wrap.txt
@@ -1,0 +1,14 @@
+Bonjour Anna,
+
+Merci pour votre message. Les conditions me semblent correctes, je serai
+disponible la semaine prochaine.
+
+Cordialement
+B
+
+
+Le lun. 15 janv. 2025 à 17:03, Anna Andersson <anna.andersson@example.com>
+a écrit:
+
+> Bonjour B, le poste est de nouveau ouvert. Êtes-vous disponible le mois
+> prochain ?

--- a/test/emails/email_it_wrap.txt
+++ b/test/emails/email_it_wrap.txt
@@ -1,0 +1,13 @@
+Ciao Anna,
+
+grazie per il messaggio. Le condizioni mi sembrano corrette, possiamo
+sentirci domani.
+
+Saluti
+B
+
+
+Il lun 15 gen 2025 alle 17:03, Anna Andersson <anna.andersson@example.com>
+ha scritto:
+
+> Ciao B, la posizione è di nuovo aperta. Sei disponibile il mese prossimo?

--- a/test/emails/email_nl_wrap.txt
+++ b/test/emails/email_nl_wrap.txt
@@ -1,0 +1,13 @@
+Hoi Anna,
+
+dank voor je bericht. De voorwaarden lijken passend; laten we morgen even
+bellen.
+
+Groet
+B
+
+
+Op ma 15 jan. 2025 17:03 Anna Andersson <anna.andersson@example.com>
+schreef:
+
+> Hoi B, de positie is weer open. Ben je volgende maand beschikbaar?

--- a/test/emails/email_sv_wrap.txt
+++ b/test/emails/email_sv_wrap.txt
@@ -1,0 +1,11 @@
+Hej Anna,
+
+tack för meddelandet. Villkoren låter rimliga, vi kan höras imorgon.
+
+/B
+
+
+Den mån 15 jan. 2025 17:03 skrev Anna Andersson <
+anna.andersson@example.com>:
+
+> Hej B, tjänsten är öppen igen. Är du tillgänglig nästa månad?

--- a/test/emails/email_swedish_3.txt
+++ b/test/emails/email_swedish_3.txt
@@ -1,0 +1,17 @@
+Hej Anna,
+låter ju potentiellt lovande. Har någon månads uppsägningstid på nuvarande
+uppdrag.
+Vi kan väl höras imorgon förmiddag (sitter på kontor, så 10.30-11.00 ungefär?).
+
+/B
+
+
+Den mån 15 jan. 2025 17:03 Anna Andersson <anna.andersson@example.com>
+skrev:
+
+> Förslaget verkar passa bra denna gång.
+>
+> * Remote i grunden, ett par kontorsdagar i början.
+> * Rätt prisbild, över 1k är inga problem.
+>
+> Vad har du för uppsägningstid?

--- a/test/test_email_reply_parser.py
+++ b/test/test_email_reply_parser.py
@@ -191,11 +191,18 @@ class EmailMessageTest(unittest.TestCase):
         self.assertTrue(mail.replies[0].signatures. startswith("Regards,"))
 
     def test_swedish_simple_body(self):
+        # email_swedish_2 ends with a wrapped Gmail header
+        # "Den fre 28 feb. 2025 10:15Anna Andersson <…> skrev:" with no sender
+        # between "skrev" and ":" — the old SV pattern required content there
+        # and so left the whole thing as one reply. With the fix the header is
+        # recognised and we get John's reply + Anna's quoted original as two
+        # replies.
         mail = self.get_email('email_swedish_2', parse=True, languages=['sv'])
-        self.assertEqual(1, len(mail.replies))
+        self.assertEqual(2, len(mail.replies))
         self.assertTrue("Hello Anna," in mail.replies[0].body)
         self.assertTrue("/John" in mail.replies[0].signatures)
         self.assertTrue("/John" not in mail.replies[0].body)
+        self.assertIn("Hej John", mail.replies[1].body)
 
     def test_swedish_quoted_reply(self):
         mail = self.get_email('email_swedish_1', parse=True, languages=['sv'])
@@ -210,6 +217,19 @@ class EmailMessageTest(unittest.TestCase):
         self.assertIn("Berättar gärna.", mail.replies[0].body)
         self.assertIn("Kan inte se att det står något", mail.replies[1].body)
         self.assertIn("Jag har försökt få tag", mail.replies[2].body)
+
+    def test_sv_wrapped_gmail_header(self):
+        """Gmail wraps long quote headers across two lines so ``skrev:`` ends
+        up alone on the next line (``Den ... <email>\\nskrev:``). The
+        cross-language ``GMAIL_WRAPPED_HEADER`` catches this layout."""
+        mail = self.get_email('email_swedish_3', parse=True, languages=['sv'])
+        self.assertEqual(2, len(mail.replies))
+        self.assertIn("Hej Anna,", mail.replies[0].body)
+        # "/B" is a Swedish-style sign-off → goes to signatures, not body.
+        self.assertIn("/B", mail.replies[0].signatures)
+        self.assertNotIn("/B", mail.replies[0].body)
+        self.assertNotIn("Förslaget verkar passa bra", mail.replies[0].body)
+        self.assertIn("Förslaget verkar passa bra", mail.replies[1].body)
 
     def test_danish_simple_body(self):
         mail = self.get_email('email_danish_1', parse=True, languages=['da'])
@@ -256,6 +276,68 @@ class EmailMessageTest(unittest.TestCase):
         return EmailReplyParser(
             languages=languages or [MAIL_LANGUAGE_DEFAULT]
         ).read(text) if parse else text
+
+
+    # ------------------------------------------------------------------
+    # Cross-language Gmail-wrapped quote headers (GMAIL_WRAPPED_HEADER).
+    # All fixtures are fully synthetic — no real names, emails, or content.
+    # ------------------------------------------------------------------
+
+    def test_en_wrapped_gmail_header(self):
+        mail = self.get_email('email_en_wrap', parse=True, languages=['en'])
+        self.assertEqual(2, len(mail.replies))
+        self.assertIn("Thanks for the offer", mail.replies[0].body)
+        self.assertNotIn("the role i mentioned", mail.replies[0].body.lower())
+        self.assertIn("the role i mentioned", mail.replies[1].body.lower())
+
+    def test_de_wrapped_gmail_header(self):
+        mail = self.get_email('email_de_wrap', parse=True, languages=['de'])
+        self.assertEqual(2, len(mail.replies))
+        self.assertIn("danke für die Nachricht", mail.replies[0].body)
+        self.assertNotIn("die Stelle ist wieder offen", mail.replies[0].body)
+        self.assertIn("die Stelle ist wieder offen", mail.replies[1].body)
+
+    def test_fr_wrapped_gmail_header(self):
+        mail = self.get_email('email_fr_wrap', parse=True, languages=['fr'])
+        self.assertEqual(2, len(mail.replies))
+        self.assertIn("Merci pour votre message", mail.replies[0].body)
+        self.assertNotIn("le poste est de nouveau ouvert", mail.replies[0].body)
+        self.assertIn("le poste est de nouveau ouvert", mail.replies[1].body)
+
+    def test_es_wrapped_gmail_header(self):
+        mail = self.get_email('email_es_wrap', parse=True, languages=['es'])
+        self.assertEqual(2, len(mail.replies))
+        self.assertIn("Gracias por escribirme", mail.replies[0].body)
+        self.assertNotIn("el puesto vuelve a estar abierto", mail.replies[0].body)
+        self.assertIn("el puesto vuelve a estar abierto", mail.replies[1].body)
+
+    def test_it_wrapped_gmail_header(self):
+        mail = self.get_email('email_it_wrap', parse=True, languages=['it'])
+        self.assertEqual(2, len(mail.replies))
+        self.assertIn("grazie per il messaggio", mail.replies[0].body)
+        self.assertNotIn("la posizione è di nuovo aperta", mail.replies[0].body)
+        self.assertIn("la posizione è di nuovo aperta", mail.replies[1].body)
+
+    def test_nl_wrapped_gmail_header(self):
+        mail = self.get_email('email_nl_wrap', parse=True, languages=['nl'])
+        self.assertEqual(2, len(mail.replies))
+        self.assertIn("dank voor je bericht", mail.replies[0].body)
+        self.assertNotIn("de positie is weer open", mail.replies[0].body)
+        self.assertIn("de positie is weer open", mail.replies[1].body)
+
+    def test_da_wrapped_gmail_header(self):
+        mail = self.get_email('email_da_wrap', parse=True, languages=['da'])
+        self.assertEqual(2, len(mail.replies))
+        self.assertIn("vilkårene lyder fornuftige", mail.replies[0].body)
+        self.assertNotIn("stillingen er åben igen", mail.replies[0].body)
+        self.assertIn("stillingen er åben igen", mail.replies[1].body)
+
+    def test_cs_wrapped_gmail_header(self):
+        mail = self.get_email('email_cs_wrap', parse=True, languages=['cs'])
+        self.assertEqual(2, len(mail.replies))
+        self.assertIn("děkuji za zprávu", mail.replies[0].body)
+        self.assertNotIn("pozice je opět otevřená", mail.replies[0].body)
+        self.assertIn("pozice je opět otevřená", mail.replies[1].body)
 
 
 if __name__ == '__main__':

--- a/test/test_email_reply_parser.py
+++ b/test/test_email_reply_parser.py
@@ -339,6 +339,26 @@ class EmailMessageTest(unittest.TestCase):
         self.assertNotIn("pozice je opět otevřená", mail.replies[0].body)
         self.assertIn("pozice je opět otevřená", mail.replies[1].body)
 
+    # ------------------------------------------------------------------
+    # Wrap-INSIDE-recipient variant: for verb-in-middle languages (sv, da,
+    # de) Gmail can also wrap inside the recipient's "<…>" bracket, putting
+    # the trailing ":" alone on the next line. Different shape, same cause.
+    # ------------------------------------------------------------------
+
+    def test_sv_wrapped_gmail_header_inside_recipient(self):
+        mail = self.get_email('email_sv_wrap', parse=True, languages=['sv'])
+        self.assertEqual(2, len(mail.replies))
+        self.assertIn("tack för meddelandet", mail.replies[0].body)
+        self.assertNotIn("tjänsten är öppen igen", mail.replies[0].body)
+        self.assertIn("tjänsten är öppen igen", mail.replies[1].body)
+
+    def test_de_wrapped_gmail_header_inside_recipient(self):
+        mail = self.get_email('email_de_wrap_inside', parse=True, languages=['de'])
+        self.assertEqual(2, len(mail.replies))
+        self.assertIn("danke für die Nachricht", mail.replies[0].body)
+        self.assertNotIn("die Stelle ist wieder offen", mail.replies[0].body)
+        self.assertIn("die Stelle ist wieder offen", mail.replies[1].body)
+
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO, stream=sys.stderr)


### PR DESCRIPTION
Gmail wraps long quote headers onto two lines, leaving the wrote-keyword alone with an optional sender + colon — same shape across locales ("On ...\nwrote:", "Den ...\nskrev:", "Am ...\nschrieb:" etc.). The per-language `wrote_header` patterns are line-anchored and require content between keyword and ":", so the wrap was missed in several languages (SV, DE, FR, ES). Other languages (EN, NL, IT) only worked because their patterns happened to use \s? where the wrap newline fits.

This is a Gmail-layout quirk, not a language one. Add two per-language tokens — `gmail_wrap_start` (the date-line prefix, e.g. "On"/"Den"/ "Am") and `gmail_wrap_keyword` (the verb on the wrap line, e.g. "wrote"/"skrev"/"schrieb") — alongside the existing `wrote_header` / `from_header`. `EmailReplyParser.HEADER_REGEX` assembles a single cross-language wrap matcher from the tokens of the *configured* languages, preserving the per-language opt-in. A language that doesn't set the tokens (e.g. ja, whose Gmail format is fundamentally different) simply doesn't contribute.

Adding a new language now needs only two extra lines on its dict; no edits to global constants or the parser.

The SV language pattern keeps a small relaxation for the non-wrap "Den ... skrev:" case (sender before keyword, no content between skrev and ":") — that's distinct from the wrap issue and was the original trigger for this PR.

All eight wrap-test fixtures are fully synthetic — no real names, emails, or content. 43/43 tests pass; no regressions in any language.