### PR TITLE
ci: add GitHub Actions workflow + status badge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # "3" = latest available CPython 3.x on the runner. No minor pin to
+        # maintain. Replace with concrete versions if you want to lock or broaden.
+        python-version:
+          - "3"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - run: pip install . pytest
+
+      - run: python -m pytest test/ -v

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Python](https://img.shields.io/badge/Made%20with-Python%203.x-blue.svg?style=flat-square&logo=Python&logoColor=white)](https://www.python.org/)
 [![Version](https://img.shields.io/badge/Version-1.3-dc2f02.svg?style=flat-square&logoColor=white)](https://github.com/alfonsrv/mail-parser-reply)
+[![test](https://github.com/alfonsrv/mail-parser-reply/actions/workflows/test.yml/badge.svg)](https://github.com/alfonsrv/mail-parser-reply/actions/workflows/test.yml)
 
 ### Multi-language email reply parsing for international environments 🌍
 


### PR DESCRIPTION
Single-job workflow runs the existing pytest suite on every push to main, every PR, and on manual dispatch. python-version: "3" picks the latest CPython 3.x on the runner — no minor pin to maintain. Adds a test-status badge to the README so build state is visible from the project page.